### PR TITLE
Fix for Wrongsnapshot plugin

### DIFF
--- a/Plugins/20 Desktop/10 Automated Pool Desktop Wrong Snapshot.ps1
+++ b/Plugins/20 Desktop/10 Automated Pool Desktop Wrong Snapshot.ps1
@@ -10,7 +10,7 @@ foreach ($pool in $pools){
 		$queryservice=new-object vmware.hv.queryserviceservice
 		$defn = New-Object VMware.Hv.QueryDefinition
 		$defn.queryentitytype='MachineSummaryView'
-		$defn.filter = New-Object VMware.Hv.QueryFilterEquals -Property @{ 'memberName' = 'base.desktop'; 'value' = "$pool.id" }
+		$defn.filter = New-Object VMware.Hv.QueryFilterEquals -Property @{ 'memberName' = 'base.desktop'; 'value' = $pool.id }
 	
 		$queryResults = $queryService.QueryService_Create($Services1, $defn)
 		$poolmachines=$services1.machine.machine_getinfos($queryResults.results.id)


### PR DESCRIPTION
Removed quotes around $pool.id so that its value is passed instead of its type.